### PR TITLE
mathmo questions on circle/line intersections

### DIFF
--- a/src/scripts/libs/qa/fractions.js
+++ b/src/scripts/libs/qa/fractions.js
@@ -277,11 +277,9 @@ function fmatrix(dim)
 			res=res.add(this[i][i].top, this[i][i].bot);
 		return(res);
 	}
-	this.write=function(l)
+	this.write=function()
 	{
-		if(typeof(l)=='undefined')
-			l=["(",")"];
-		var res="\\left"+l[0]+"\\begin{pmatrix}";
+		var res="\\begin{pmatrix}";
 		for(var i=0;i<this.dim;i++)
 		{
 			for(var j=0;j<this.dim;j++)
@@ -291,7 +289,7 @@ function fmatrix(dim)
 				{
 					if(i==this.dim-1)
 					{
-						res+="\\end{pmatrix}\\right"+l[1];
+						res+="\\end{pmatrix};
 					}
 					else
 					{

--- a/src/scripts/libs/qa/fractions.js
+++ b/src/scripts/libs/qa/fractions.js
@@ -289,7 +289,7 @@ function fmatrix(dim)
 				{
 					if(i==this.dim-1)
 					{
-						res+="\\end{pmatrix};
+						res+="\\end{pmatrix}";
 					}
 					else
 					{

--- a/src/scripts/libs/qa/fractions.js
+++ b/src/scripts/libs/qa/fractions.js
@@ -281,7 +281,7 @@ function fmatrix(dim)
 	{
 		if(typeof(l)=='undefined')
 			l=["(",")"];
-		var res="\\left"+l[0]+"\\begin{array}{"+"c".repeat(this.dim)+"}";
+		var res="\\left"+l[0]+"\\begin{pmatrix}";
 		for(var i=0;i<this.dim;i++)
 		{
 			for(var j=0;j<this.dim;j++)
@@ -291,7 +291,7 @@ function fmatrix(dim)
 				{
 					if(i==this.dim-1)
 					{
-						res+="\\end{array}\\right"+l[1];
+						res+="\\end{pmatrix}\\right"+l[1];
 					}
 					else
 					{

--- a/src/scripts/libs/qa/geometry.js
+++ b/src/scripts/libs/qa/geometry.js
@@ -43,7 +43,12 @@ function circleEq2(a,b,r)
     eqString += "+y^2"+signedNumber(-2*b)+"y";
   }
 
-  eqString += "="+C;
+  if (C<0) {
+    eqString += signedNumber(-C)+"=0";
+  } else {
+    eqString += "="+C;
+  }
+
   return eqString;
 }
 

--- a/src/scripts/libs/qa/geometry.js
+++ b/src/scripts/libs/qa/geometry.js
@@ -20,7 +20,7 @@ function circleEq1(a,b,r)
     eqString += "+(y"+signedNumber(-b)+")^2=";
   }
 
-  eqString += +r^2;
+  eqString += +r*r;
   return eqString;
 }
 
@@ -28,7 +28,7 @@ function circleEq1(a,b,r)
 // x^2 - 2ax + y^2 - 2bx = c
 function circleEq2(a,b,r)
 {
-  var C=r^2-a^2-b^2;
+  var C=r*r-a*a-b*b;
   var eqString="";
 
   if (a==0) {

--- a/src/scripts/libs/qa/helpers.js
+++ b/src/scripts/libs/qa/helpers.js
@@ -375,7 +375,7 @@ String.prototype.repeat = function(num)
 // Returns a number signed with + or - as a string
 // Useful for equations
 
-function signedNumber(x) // What about x = +/-1?
+function signedNumber(x)
 {
     if (x > 0) {
         return "+" + x;

--- a/src/scripts/libs/qa/helpers.js
+++ b/src/scripts/libs/qa/helpers.js
@@ -369,17 +369,135 @@ function epsi(i, j, k)
 
 String.prototype.repeat = function(num)
 {
-    return(new Array(num+1).join(this));
+  return(new Array(num+1).join(this));
 };
 
 // Returns a number signed with + or - as a string
 // Useful for equations
-
 function signedNumber(x)
 {
-    if (x > 0) {
-        return "+" + x;
+  if (x > 0) {
+    return "+" + x;
+  } else {
+    return x.toString();
+  }
+}
+
+// Simplifies a root of the form (a+b sqrt c)/d
+// Takes a 4-tuple [a,b,c,d] and returns a LaTeX formatted string
+function simplifySurd(a,b,c,d)
+{
+  var sq=new sqroot(c);
+  var B=sq.a*b;
+  var C=sq.n;
+  var eqString="";
+
+  if (d==0) { // This shouldn't happen, but let's throw a helpful error message
+    eqString+="Error; zero in denominator";
+  }
+  else if (a==0) // Surd of the form (b sqrt c)/d
+  {
+    var f=new frac(B,d);
+    if (f.top==1) {
+      var top="";
+    } else if (f.top==-1) {
+      var top="-";
     } else {
-        return x.toString();
+      var top=f.top;
     }
+
+    if (f.bot==1) {
+      eqString+=top + "\\sqrt{"+C+"}";
+    } else {
+      eqString+="\\frac{"+top+"\\sqrt{"+C+"}}{"+f.bot+"}";
+    }
+  }
+  else if (B==0||C==0) // This is the fairly simple a/d
+  {
+    var f=new frac(a,d);
+    eqString+=f.write();
+  }
+  else if (C==1) // Another simple case (a+b)/d
+  {
+    var f=new frac(a+b,d);
+    eqString+=f.write();
+  } else {
+    // Final case
+    // Here we have a non-trivial root, and every term is non-zero
+
+    // eqString+="non-trivial case";
+
+    // Simplify the terms
+    var h=gcd(a,B,d);
+    a/=h; B/=h; d/=h;
+
+    if (d<0) {
+      a*=-1;
+      B*=-1;
+      d*=-1;
+    }
+
+    function innerSurd(a,b,c)
+    // This simplifies the denominator a+b sqrt(c) and returns a LaTeX-formatted string
+    // It assumes that all arguments are non-zero and that c!=1
+    // These cases have already been caught earlier
+    {
+      var surdString=a;
+      if (b==1) {
+        surdString+="+\\sqrt{"+c+"}";
+      } else if (b==-1) {
+        surdString+="-\\sqrt{"+c+"}";
+      } else {
+        surdString+=signedNumber(b)+"\\sqrt{"+c+"}";
+      }
+      return surdString
+    }
+
+    if (d==1) {
+      eqString+=innerSurd(a,B,c);
+    } else {
+      eqString+="\\frac{"+innerSurd(a,B,c)+"}{"+d+"}";
+    }
+  }
+
+  // if (B==0) {
+  //   var f=new frac(a,d);
+  //   eqString+=f.write();
+  // }
+  // else if (C==1)
+  // {
+  //   var f=new frac(a+B,d);
+  //   eqString+=f.write();
+  // }
+  // else
+  // { // Non-trivial term in the root
+  //   var h=gcd(a,B,d);
+  //   a/=h; B/=h; d/=h;
+
+  //   if (B==1) {
+  //     B="+";
+  //   } else if (B==-1) {
+  //     B="-";
+  //   } else {
+  //     B=signedNumber(B);
+  //   }
+
+  //   if (d==1) // Unit denominator
+  //   {
+  //     eqString+=a+signedNumber(B)+"\\sqrt{"+C+"}";
+  //   }
+  //   else
+  //   {
+  //     if (a%d==0||B%d==0)
+  //     {
+  //       eqString+="still a bit to do";
+  //     }
+  //     else
+  //     {
+  //       // Both pieces are fractions
+  //       eqString+="\\frac{"+a+B+"\\sqrt{"+C+"}}{"+d+"}";
+  //     }
+  //   }
+  // }
+  return eqString;
 }

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -686,31 +686,41 @@ function makeCircLineInter()
     // Variables to solve Ax^2 + Bx + C = 0
     var A=m*m+1;
     var B=-2*a+2*m*(c-b);
-    var C=(c-b)*(c-b)-r*r;
+    var C=(c-b)*(c-b)-r*r+a*a;
 
     var disc=B*B-4*A*C;
     var sq=new sqroot(disc);
 
     if (disc>0) {
-      var aString="The line and the circle intersection in two points, specifically ";
+      var aString="The line and the circle intersect in two points, specifically ";
 
-      // First solution
       var xint1=new frac(-B,2*A);
-      var xint2=new frac(Math.abs(sq.a),2*A);
+      var xint2=new frac(sq.a,2*A);
 
       var yint1=new frac(-B*m+2*A*c,2*A);
-      var yint2=new frac(m*Math.abs(sq.a),2*A);
+      var yint2=new frac(m*sq.a,2*A);
 
       // Finish tinkering with this
 
       // First solution
       aString+="$$\\left(\\frac{"
       if (xint1.bot==xint2.bot) {
-        aString+=xint1.top+signedNumber(xint2.top)+"\\sqrt{"+sq.n+"}}{"+xint1.bot+"}\\right)$$";
+        aString+=xint1.top+"+"+xint2.top+"\\sqrt{"+sq.n+"}}{"+xint1.bot+"},";
       } else {
-        aString+=xint1.write();
+        aString+=xint1.top+"}{"+xint1.bot+"}+\\frac{"+xint2.top+"\\sqrt{"+sq.n+"}}{"+xint2.bot+"},";
       }
-      aString+="$$\\textstyle\\left("+xint1.top+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
+      aString+="\\frac{";
+      if (yint1.bot==yint2.bot) {
+        aString+=yint1.top+signedNumber(yint2.top)+"\\sqrt{"+sq.n+"}}{"+yint1.bot+"}";
+      } else {
+        aString+=yint1.top+"}{"+yint1.bot+"}+\\frac{"+yint2.top+"\\sqrt{"+sq.n+"}}{"+yint2.bot+"}";
+      }
+      aString+="\\right)";
+
+      aString+="\\qquad\\text{and}\\qquad ";
+      aString+="$$";
+
+      // aString+="$$\\textstyle\\left("+xint1.top+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
 
       // // First solution
       // aString+=xint1.write()+"+"+new frac(sq.a,2*A).write()+"\\sqrt{"+sq.n+"}";

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -694,14 +694,23 @@ function makeCircLineInter()
     if (disc>0) {
       var aString="The line and the circle intersection in two points, specifically ";
 
+      // First solution
       var xint1=new frac(-B,2*A);
       var xint2=new frac(Math.abs(sq.a),2*A);
 
       var yint1=new frac(-B*m+2*A*c,2*A);
       var yint2=new frac(m*Math.abs(sq.a),2*A);
 
+      // Finish tinkering with this
+
       // First solution
-      aString+="$$\\textstyle\\left("+xint1.write()+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
+      aString+="$$\\left(\\frac{"
+      if (xint1.bot==xint2.bot) {
+        aString+=xint1.top+signedNumber(xint2.top)+"\\sqrt{"+sq.n+"}}{"+xint1.bot+"}\\right)$$";
+      } else {
+        aString+=xint1.write();
+      }
+      aString+="$$\\textstyle\\left("+xint1.top+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
 
       // // First solution
       // aString+=xint1.write()+"+"+new frac(sq.a,2*A).write()+"\\sqrt{"+sq.n+"}";

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -627,7 +627,7 @@ function makeCircLineInter()
       c2=rand(6);
     }
 
-    var qString="Find whether the lines \\(";
+    var qString="Consider the lines \\(";
 
     if (rand()) {
       qString+=lineEq1(0,c1,1,m1+c1);
@@ -643,7 +643,7 @@ function makeCircLineInter()
       qString+=lineEq2(m2,c2);
     }
 
-    qString+="\\) intersect, and if they do, find their point of intersection."
+    qString+="\\). <br><br> Find out how many points of intersection they have, and the location of any intersections."
 
     if (m1==m2) {
       var aString="The lines do not intersect.";
@@ -681,7 +681,7 @@ function makeCircLineInter()
       qString+=circleEq2(a,b,r);
     }
 
-    qString+="\\). Find out how many points of intersection they have, and the location of any intersections."
+    qString+="\\). <br><br> Find out how many points of intersection they have, and the location of any intersections."
 
     // By substitution, we can get an equation of the form Ax^ + Bx + C = 0
     // The roots are the points of intersection
@@ -743,7 +743,7 @@ function makeCircLineInter()
       r2=rand(2,7);
     }
 
-    var qString="Consider the circles with equations \\(";
+    var qString="Consider the circles \\(";
 
     if (rand()) {
       qString+=circleEq1(a1,b1,r1);
@@ -761,24 +761,57 @@ function makeCircLineInter()
 
     qString+="\\). <br><br> Find out how many points of intersection they have, and the location of any intersections."
 
-    var d=Math.sqrt((b2-b1)*(b2-b1)+(a2-a1)*(a2-a1));
+    var D=Math.sqrt((b2-b1)*(b2-b1)+(a2-a1)*(a2-a1));
+    var DD=(b2-b1)*(b2-b1)+(a2-a1)*(a2-a1);
     var R=r1+r2;
+    var RR=r1*r1-r2*r2;
+    var S=Math.abs(r1-r2);
 
-    if (d>R) {
-      var aString="The two circles do not intersect in any points.";
-    } else if (d>R) {
-      var aString="Two intersections";
+    // The formulae for the case of two intersections is cribbed from
+    // http://www.ambrsoft.com/TrigoCalc/Circles2/Circle2.htm
+
+    if (R>D&&D>S) {
+      var aString="The circles intersect in two points, which are";
+
+      var d=new sqroot(-DD*DD+2*DD*r1*r1-r1*r1*r1*r1+2*DD*r2*r2+2*r1*r1*r2*r2-r2*r2*r2*r2);
+
+      // First solution
+      aString+="$$\\left(";
+      aString+=simplifySurd((a1+a2)*DD+(a2-a1)*RR,(b1-b2)*d.a,d.n,2*DD);
+      aString+=","+simplifySurd((b1+b2)*DD+(b2-b1)*RR,(a2-a1)*d.a,d.n,2*DD);
+      aString+="\\right)";
+
+      aString+="\\qquad\\text{and}\\qquad ";
+
+      // Second solution
+      aString+="\\left(";
+      aString+=simplifySurd((a1+a2)*DD+(a2-a1)*RR,(b2-b1)*d.a,d.n,2*DD);
+      aString+=","+simplifySurd((b1+b2)*DD+(b2-b1)*RR,(a1-a2)*d.a,d.n,2*DD);
+      aString+="\\right)";
+
+      aString+="$$";
     } else if (d==R) {
       var x1=new frac(a1*R+r1*(a2-a1),R);
       var y1=new frac(b1*R+r1*(b2-b1),R);
       var aString="The circles intersect in a single point, which is \\(("+x1.write()+","+y1.write()+")\\).";
+    } else if (D>R||D<=S) {
+      var aString="The two circles do not intersect in any points.";
+    } else {
+      var aString="Uh oh";
     }
 
     var qa=[qString,aString];
     return qa;
   }
 
-  var qa=makeCCInter();
+  if (rand()) {
+    var qa=makeCLInter();
+  } else if (rand()) {
+    var qa=makeLLInter();
+  } else {
+    var qa=makeCCInter();
+  }
+
   return qa;
 }
 

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -2418,15 +2418,22 @@ function makeMatXforms()
 	for(var i=0;i<5;i++) {xfms[i]=new fmatrix(2);}
 	var cosines = [new frac(0), new frac(-1), new frac(0)];
 	var sines = [new frac(1), new frac(0), new frac(-1)];
-	xfms[0].set(cosines[a], -sines[a], sines[a], cosines[a]);
-	xfms[1].set(cosines[a], sines[a], sines[a], -cosines[a]);
+  var acosines = [new frac(0), new frac(1), new frac(0)];
+  var asines = [new frac(-1), new frac(0), new frac(1)];
+	xfms[0].set(cosines[a], asines[a], sines[a], cosines[a]); // first sin is -1
+	xfms[1].set(cosines[a], sines[a], sines[a], acosines[a]); // second cos is -1
 	xfms[2].set(1, a + 1, 0, 1);
 	xfms[3].set(1, 0, a + 1, 1);
 	xfms[4].set(a+2, 0, 0, a+2);
 	var f=new frac(a+1, 2);
-	var xft=["a rotation through \\("+fcoeff(f, "\\pi")+"\\) anticlockwise about O", "a reflection in the line \\("+["y=x","x=0","y=-x"][a]+"\\)", "a shear of element \\("+(a+1)+", x\\) axis invariant", "a shear of element \\("+(a+1)+", y\\) axis invariant", "an enlargement of scale factor \\("+(a+1)+"\\)"];
+	var xft=[
+    "a rotation through \\("+fcoeff(f, "\\pi")+"\\) anticlockwise about O",
+    "a reflection in the line \\("+["y=x","x=0","y=-x"][a]+"\\)",
+    "a shear of element \\("+(a+1)+", x\\) axis invariant",
+    "a shear of element \\("+(a+1)+", y\\) axis invariant",
+    "an enlargement of scale factor \\("+(a+1)+"\\)"];
 	var which=distrand(2, 0, 4);
-	var qString="Compute the matrix representing, in 2D, "+xft[which[0]]+" followed by "+xft[which[1]];
+	var qString="Compute the matrix representing, in 2D, "+xft[which[0]]+" followed by "+xft[which[1]]+".";
 	var ans=xfms[which[1]].times(xfms[which[0]]);
 	var aString="$$"+ans.write()+"$$";
 	var qa=[qString,aString];

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -2169,10 +2169,10 @@ function makeFurtherVector()
 	var a=new vector(3);a.setrand(5);
 	var b=new vector(3);b.setrand(5);
 	var c=new vector(3);c.setrand(5);
-	var qString="Let \\(a="+a.write()+"\\)\\,,\\; \\(b="+b.write()+"\\,\\) and \\(c="+c.write()+"\\). ";
+	var qString="Let \\(\\mathbf{a}="+a.write()+"\\,\\),\\; \\(\\mathbf{b}="+b.write()+"\\,\\) and \\(\\mathbf{c}="+c.write()+"\\). ";
 	qString += "Calculate: <ul class=\"exercise\">";
-	qString += "<li>the vector product, \\(a\\wedge b\\),</li>";
-	qString += "<li>the scalar triple product, \\([a, b, c]\\).</li>";
+	qString += "<li>the vector product, \\(\\mathbf{a}\\wedge \\mathbf{b}\\),</li>";
+	qString += "<li>the scalar triple product, \\([\\mathbf{a}, \\mathbf{b}, \\mathbf{c}]\\).</li>";
 	qString += "</ul>";
 	var axb=a.cross(b);
 	var abc=axb.dot(c);

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -492,7 +492,7 @@ function makeLineParPerp()
       while (a==c) {
         c=rand(5);
       }
-      qString += "\\(x="+e+"\\).";
+      qString += "\\(x="+c+"\\).";
       var aString="$$x="+a+".$$";
     } else {
       if (rand()) {
@@ -930,7 +930,7 @@ function makeFactor()
 		u[0]=a;v[0]=b;w[0]=c;
 		var x=polyexpand(polyexpand(u, v), w);
 		var qString="Use the factor theorem to factorise $$"+x.write()+".$$";
-		var aString=express([a, b, c]);
+		var aString="$$"+express([a, b, c])+"$$";
 		var qa=[qString,aString];
 		return qa;
 	}
@@ -1019,7 +1019,7 @@ function makeComplete()
 	if(rand())
 	{
 		qString="By completing the square, find (for real \\(x\\)) the minimum value of$$"+p.write()+".$$";
-		aString="The minimum value is \\("+b+"\\) which occurs at \\(x="+a+"\\)";
+		aString="The minimum value is \\("+b+",\\) which occurs at \\(x="+a+"\\).";
 	}
 	else
 	{
@@ -1061,7 +1061,7 @@ function makeLog()
 		var a=pickrand(2,3,5);
 		var m=rand(1,4);
 		var n=rand(1,4);if(n>=m) n++;
-		var qString="If \\("+Math.pow(a,m)+"="+Math.pow(a,n)+"^{x}\\) find \\(x\\).";
+		var qString="If \\("+Math.pow(a,m)+"="+Math.pow(a,n)+"^{x},\\) then find \\(x\\).";
 		var r=new frac(m,n);
 		var aString="$$x="+r.write()+"$$";
 		var qa=[qString,aString];
@@ -1081,7 +1081,7 @@ function makeLog()
 	{
 		var a=rand(2,7);
 		var b=Math.floor(Math.pow(a,7*Math.random()));
-		var qString="If \\("+a+"^{x}="+b+"\\), find \\(x\\) to three decimal places.";
+		var qString="If \\("+a+"^{x}="+b+"\\), then find \\(x\\) to three decimal places.";
 		var c=new Number(Math.log(b)/Math.log(a));
 		var aString="$$x="+c.toFixed(3)+"$$";
 		var qa=[qString,aString];

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -424,15 +424,15 @@ function makeLinesEq()
 {
   function makeLines1()
   {
-    var a=rand(5);
-    var b=rand(5);
-    var c=rand(5);
-    var d=rand(5);
+    var a=rand(6);
+    var b=rand(6);
+    var c=rand(6);
+    var d=rand(6);
 
     while (a==c && b==d) // Check for degeneracy
     {
-      c=rand(5);
-      d=rand(5);
+      c=rand(6);
+      d=rand(6);
     }
 
     var qString="Find the equation of the line passing through \\(("+a+","+b+")\\) and \\(("+c+","+d+")\\).";
@@ -479,10 +479,10 @@ function makeLinesEq()
 // Lines parallel or perpendicular to a point
 function makeLineParPerp()
 {
-  var a=rand(5);
-  var b=rand(5);
+  var a=rand(6);
+  var b=rand(6);
   var m=rand(6); // If m=6 then we treat it as vertical
-  var c=rand(5);
+  var c=rand(6);
 
   function makeLinePar(a,b,m,c) {
 
@@ -578,9 +578,9 @@ function makeLineParPerp()
 // Equations of circles
 function makeCircleEq()
 {
-  var r=rand(1,6);
-  var a=rand(5);
-  var b=rand(5);
+  var r=rand(2,7);
+  var a=rand(6);
+  var b=rand(6);
 
   function makeCircleEq1(a,b,r) {
     var qString="Find the equation of the circle with centre \\(("+a+","+b+")\\) and radius \\("+r+"\\).";

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -683,56 +683,45 @@ function makeCircLineInter()
 
     qString+="\\). Find out how many points of intersection they have, and the location of any intersections."
 
-    // Variables to solve Ax^2 + Bx + C = 0
+    // By substitution, we can get an equation of the form Ax^ + Bx + C = 0
+    // The roots are the points of intersection
+    // We compute these variables:
     var A=m*m+1;
     var B=-2*a+2*m*(c-b);
     var C=(c-b)*(c-b)-r*r+a*a;
 
+    // Discriminant for the roots
     var disc=B*B-4*A*C;
     var sq=new sqroot(disc);
 
     if (disc>0) {
       var aString="The line and the circle intersect in two points, specifically ";
 
-      var xint1=new frac(-B,2*A);
-      var xint2=new frac(sq.a,2*A);
-
-      var yint1=new frac(-B*m+2*A*c,2*A);
-      var yint2=new frac(m*sq.a,2*A);
-
-      // Finish tinkering with this
-
-      // First solution
-      aString+="$$\\left(\\frac{"
-      if (xint1.bot==xint2.bot) {
-        aString+=xint1.top+"+"+xint2.top+"\\sqrt{"+sq.n+"}}{"+xint1.bot+"},";
-      } else {
-        aString+=xint1.top+"}{"+xint1.bot+"}+\\frac{"+xint2.top+"\\sqrt{"+sq.n+"}}{"+xint2.bot+"},";
-      }
-      aString+="\\frac{";
-      if (yint1.bot==yint2.bot) {
-        aString+=yint1.top+signedNumber(yint2.top)+"\\sqrt{"+sq.n+"}}{"+yint1.bot+"}";
-      } else {
-        aString+=yint1.top+"}{"+yint1.bot+"}+\\frac{"+yint2.top+"\\sqrt{"+sq.n+"}}{"+yint2.bot+"}";
-      }
+      // First solution x1 = (-B+sqrt(disc))/2A, y=m*x1+c
+      aString+="$$\\left("
+      aString+=simplifySurd(-B,sq.a,sq.n,2*A);
+      aString+=","+simplifySurd(-m*B+2*c*A,m*sq.a,sq.n,2*A);
       aString+="\\right)";
 
       aString+="\\qquad\\text{and}\\qquad ";
+
+      // Second solution x2 = (-B-sqrt(disc))/2A, y=m*x2+c
+      aString+="\\left("
+      aString+=simplifySurd(-B,-sq.a,sq.n,2*A);
+      aString+=","+simplifySurd(-m*B+2*c*A,-m*sq.a,sq.n,2*A);
+      aString+="\\right)";
+
       aString+="$$";
-
-      // aString+="$$\\textstyle\\left("+xint1.top+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
-
-      // // First solution
-      // aString+=xint1.write()+"+"+new frac(sq.a,2*A).write()+"\\sqrt{"+sq.n+"}";
-      // aString+=sq.a+" "+sq.n+" and break "+sq.write();
-    } else if (disc<0) {
+    }
+    else if (disc<0)
+    {
       var aString="The line and the circle do not intersect in any points.";
-    } else if (disc==0) { // This never happens in practice; do we want to artificially increase it?
+    }
+    else if (disc==0)
+    { // This never happens in practice; do we want to artificially increase it?
       var xint=new frac(-B,2*A);
       var yint=new frac(-B*m+c*2*A,2*A);
       var aString="The line and the circle intersect in exactly one point, which occurs at \\(\\left("+xint.write()+","+yint.write()+"\\right)\\).";
-    } else {
-      console.log("The discriminant in the equation for x in makeCLInter is not a number.")
     }
 
     var qa=[qString,aString];

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -728,7 +728,57 @@ function makeCircLineInter()
     return qa;
   }
 
-  var qa=makeCLInter();
+  function makeCCInter() {
+    var a1=rand(6);
+    var b1=rand(6);
+    var r1=rand(2,7);
+
+    var a2=rand(6);
+    var b2=rand(6);
+    var r2=rand(2,7);
+
+    while (a1==a2&&b1==b2&&r1==r2) {
+      a2=rand(6);
+      b2=rand(6);
+      r2=rand(2,7);
+    }
+
+    var qString="Consider the circles with equations \\(";
+
+    if (rand()) {
+      qString+=circleEq1(a1,b1,r1);
+    } else {
+      qString+=circleEq2(a1,b1,r1);
+    }
+
+    qString+="\\) and \\("
+
+    if (rand()) {
+      qString+=circleEq1(a2,b2,r2);
+    } else {
+      qString+=circleEq2(a2,b2,r2);
+    }
+
+    qString+="\\). <br><br> Find out how many points of intersection they have, and the location of any intersections."
+
+    var d=Math.sqrt((b2-b1)*(b2-b1)+(a2-a1)*(a2-a1));
+    var R=r1+r2;
+
+    if (d>R) {
+      var aString="The two circles do not intersect in any points.";
+    } else if (d>R) {
+      var aString="Two intersections";
+    } else if (d==R) {
+      var x1=new frac(a1*R+r1*(a2-a1),R);
+      var y1=new frac(b1*R+r1*(b2-b1),R);
+      var aString="The circles intersect in a single point, which is \\(("+x1.write()+","+y1.write()+")\\).";
+    }
+
+    var qa=[qString,aString];
+    return qa;
+  }
+
+  var qa=makeCCInter();
   return qa;
 }
 

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -609,6 +609,121 @@ function makeCircleEq()
   return qa;
 }
 
+function makeCircLineInter()
+{
+  function makeLLInter()
+  {
+    m1=rand(6);
+    m2=rand(6);
+    c1=rand(6);
+    c2=rand(6);
+
+    if (rand()) { // Artificially increase the number of parallel lines
+      m1=m2;
+    }
+
+    while(m1==m2&&c1==c2) {
+      m2=rand(6);
+      c2=rand(6);
+    }
+
+    var qString="Find whether the lines \\(";
+
+    if (rand()) {
+      qString+=lineEq1(0,c1,1,m1+c1);
+    } else {
+      qString+=lineEq2(m1,c1);
+    }
+
+    qString+="\\) and \\(";
+
+    if (rand()) {
+      qString+=lineEq1(0,c2,1,m2+c2);
+    } else {
+      qString+=lineEq2(m2,c2);
+    }
+
+    qString+="\\) intersect, and if they do, find their point of intersection."
+
+    if (m1==m2) {
+      var aString="The lines do not intersect.";
+    } else {
+      var xint=new frac(c2-c1,m1-m2);
+      var yint=new frac(m1*(c2-c1)+c1*(m1-m2),m1-m2);
+      var aString="The lines intersect in a single point, which occurs at \\(\\left("+xint.write()+","+yint.write()+"\\right)\\).";
+    }
+
+    var qa=[qString,aString];
+    return qa;
+  }
+
+  function makeCLInter() {
+    var a=rand(6);
+    var b=rand(6);
+    var r=rand(2,7);
+
+    var m=rand(6);
+    var c=rand(6);
+
+    var qString="Consider the line \\(";
+
+    if (rand()) {
+      qString+=lineEq1(0,c,1,m+c);
+    } else {
+      qString+=lineEq2(m,c);
+    }
+
+    qString+="\\) and the circle \\( "
+
+    if (rand()) {
+      qString+=circleEq1(a,b,r);
+    } else {
+      qString+=circleEq2(a,b,r);
+    }
+
+    qString+="\\). Find out how many points of intersection they have, and the location of any intersections."
+
+    // Variables to solve Ax^2 + Bx + C = 0
+    var A=m*m+1;
+    var B=-2*a+2*m*(c-b);
+    var C=(c-b)*(c-b)-r*r;
+
+    var disc=B*B-4*A*C;
+    var sq=new sqroot(disc);
+
+    if (disc>0) {
+      var aString="The line and the circle intersection in two points, specifically ";
+
+      var xint1=new frac(-B,2*A);
+      var xint2=new frac(Math.abs(sq.a),2*A);
+
+      var yint1=new frac(-B*m+2*A*c,2*A);
+      var yint2=new frac(m*Math.abs(sq.a),2*A);
+
+      // First solution
+      aString+="$$\\textstyle\\left("+xint1.write()+"+"+xint2.write()+"\\sqrt{"+sq.n+"},"+yint1.write()+"+"+yint2.write()+"\\sqrt{"+sq.n+"}\\right)$$";
+
+      // // First solution
+      // aString+=xint1.write()+"+"+new frac(sq.a,2*A).write()+"\\sqrt{"+sq.n+"}";
+      // aString+=sq.a+" "+sq.n+" and break "+sq.write();
+    } else if (disc<0) {
+      var aString="The line and the circle do not intersect in any points.";
+    } else if (disc==0) { // This never happens in practice; do we want to artificially increase it?
+      var xint=new frac(-B,2*A);
+      var yint=new frac(-B*m+c*2*A,2*A);
+      var aString="The line and the circle intersect in exactly one point, which occurs at \\(\\left("+xint.write()+","+yint.write()+"\\right)\\).";
+    } else {
+      console.log("The discriminant in the equation for x in makeCLInter is not a number.")
+    }
+
+    var qa=[qString,aString];
+    return qa;
+  }
+
+  var qa=makeCLInter();
+  return qa;
+}
+
 function makeIneq()
 {
 	function makeIneq2()

--- a/src/scripts/libs/qa/problems.js
+++ b/src/scripts/libs/qa/problems.js
@@ -550,21 +550,25 @@ function makeLineParPerp()
       }
 
       // Intercept in y=mx+c
-      if (C%1==0) {
+      if (C%1==0&&C!==0) {
         aString+=signedNumber(C);
       } else {
         if (C>0) {
           aString+="+"+intercept.write();
-        } else {
+        } else if (C<0) {
           aString+=intercept.write();
         }
       }
 
       aString+="\\qquad\\text{or}\\qquad ";
 
-      aString+="x"+signedNumber(m)+"y"+signedNumber(-b*m-a)+"=0";
+      aString+="x"+signedNumber(m)+"y";
 
-      aString+=".$$";
+      if (-b*m-a!==0) {
+        aString+=signedNumber(-b*m-a);
+      }
+
+      aString+="=0.$$";
     }
 
     var qa=[qString,aString];

--- a/src/scripts/pubs/mathmo/services/config.ls
+++ b/src/scripts/pubs/mathmo/services/config.ls
@@ -34,6 +34,7 @@ angular.module('app').factory 'config', ->
           "C31"
           "C32"
           "C33"
+          "C44"
 
     * title: "Sequences & series"
       topicIds:
@@ -195,6 +196,9 @@ angular.module('app').factory 'config', ->
       "C33":
         * "Parallel and perpendicular lines"
           makeLineParPerp
+      "C44":
+        * "Intersections of circles and lines"
+          makeCircLineInter
 
       "F1":
         * "Complex Arithmetic"

--- a/src/scripts/pubs/mathmo/services/config.ls
+++ b/src/scripts/pubs/mathmo/services/config.ls
@@ -34,7 +34,7 @@ angular.module('app').factory 'config', ->
           "C31"
           "C32"
           "C33"
-          "C44"
+          "C34"
 
     * title: "Sequences & series"
       topicIds:
@@ -196,7 +196,7 @@ angular.module('app').factory 'config', ->
       "C33":
         * "Parallel and perpendicular lines"
           makeLineParPerp
-      "C44":
+      "C34":
         * "Intersections of circles and lines"
           makeCircLineInter
 

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -95,7 +95,7 @@ describe "mathmoController", ->
       "makeFactor2"
       "C9"
       "Use the factor theorem to factorise $$x^3 + x^2 - 17x + 15.$$"
-      "(x - 3)(x - 1)(x + 5)"
+      "$$(x - 3)(x - 1)(x + 5)$$"
       10
     ]
     [
@@ -126,7 +126,7 @@ describe "mathmoController", ->
     [
       "makeLog"
       "C13"
-      "If \\(125=3125^{x}\\) find \\(x\\)."
+      "If \\(125=3125^{x},\\) then find \\(x\\)."
       "$$x=\\frac{3}{5}$$"
     ]
     [
@@ -304,8 +304,8 @@ describe "mathmoController", ->
     [
       "makeMatrix2"
       "F4"
-      "Let $$A=\\left(\\begin{pmatrix}5&-4\\\\-5&1\\end{pmatrix}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{pmatrix}-4&2\\\\5&3\\end{pmatrix}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
-      "<ul class=\"exercise\"><li>\\(\\left(\\begin{pmatrix}1&-2\\\\0&4\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-40&-2\\\\25&-7\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-\\frac{3}{22}&\\frac{1}{11}\\\\\\frac{5}{22}&\\frac{2}{11}\\end{pmatrix}\\right)\\)</li></ul>"
+      "Let $$A=\\begin{pmatrix}5&-4\\\\-5&1\\end{pmatrix} \\qquad \\text{and} \\qquad B=\\begin{pmatrix}-4&2\\\\5&3\\end{pmatrix}$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
+      "<ul class=\"exercise\"><li>\\(\\begin{pmatrix}1&-2\\\\0&4\\end{pmatrix}\\)</li><li>\\(\\begin{pmatrix}-40&-2\\\\25&-7\\end{pmatrix}\\)</li><li>\\(\\begin{pmatrix}-\\frac{3}{22}&\\frac{1}{11}\\\\\\frac{5}{22}&\\frac{2}{11}\\end{pmatrix}\\)</li></ul>"
     ]
     [
       "makeTaylor"
@@ -322,8 +322,8 @@ describe "mathmoController", ->
     [
       "makeMatrix3"
       "F7"
-      "Let $$A=\\left(\\begin{pmatrix}3&1&2\\\\3&-3&1\\\\3&-4&-2\\end{pmatrix}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{pmatrix}-4&-2&2\\\\-2&-2&3\\\\-3&3&2\\end{pmatrix}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
-      "<ul class=\"exercise\"><li>\\(\\left(\\begin{pmatrix}-1&-1&4\\\\1&-5&4\\\\0&-1&0\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-20&-2&13\\\\-9&3&-1\\\\2&-4&-10\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-\\frac{13}{38}&\\frac{5}{19}&-\\frac{1}{19}\\\\-\\frac{5}{38}&-\\frac{1}{19}&\\frac{4}{19}\\\\-\\frac{6}{19}&\\frac{9}{19}&\\frac{2}{19}\\end{pmatrix}\\right)\\)</li></ul>"
+      "Let $$A=\\begin{pmatrix}3&1&2\\\\3&-3&1\\\\3&-4&-2\\end{pmatrix} \\qquad \\text{and} \\qquad B=\\begin{pmatrix}-4&-2&2\\\\-2&-2&3\\\\-3&3&2\\end{pmatrix}$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
+      "<ul class=\"exercise\"><li>\\(\\begin{pmatrix}-1&-1&4\\\\1&-5&4\\\\0&-1&0\\end{pmatrix}\\)</li><li>\\(\\begin{pmatrix}-20&-2&13\\\\-9&3&-1\\\\2&-4&-10\\end{pmatrix}\\)</li><li>\\(\\begin{pmatrix}-\\frac{13}{38}&\\frac{5}{19}&-\\frac{1}{19}\\\\-\\frac{5}{38}&-\\frac{1}{19}&\\frac{4}{19}\\\\-\\frac{6}{19}&\\frac{9}{19}&\\frac{2}{19}\\end{pmatrix}\\)</li></ul>"
     ]
     [
       "makeFurtherVector"

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -262,20 +262,26 @@ describe "mathmoController", ->
     [
       "makeLines2D"
       "C31"
-      "Find the equation of the line passing through \\((5,-2)\\) and \\((5,-5)\\)."
-      "$$x=5.$$"
+      "Find the equation of the line passing through \\((6,-3)\\) and \\((6,-6)\\)."
+      "$$x=6.$$"
     ]
     [
       "makeCircleEq"
       "C32"
-      "Find the centre and radius of the circle with equation$$x^2+6x+y^2+6y=6.$$"
-      "The circle has centre \\((-3,-3)\\) and radius \\(4  \\)."
+      "Find the centre and radius of the circle with equation$$x^2+8x+y^2+6y=0.$$"
+      "The circle has centre \\((-4,-3)\\) and radius \\(5  \\)."
     ]
     [
       "makeLineParPerp"
       "C33"
-      "Find the equation of the line passing through \\((0,2)\\) and perpendicular to the line \\(y=1\\)."
-      "$$x=0.$$"
+      "Find the equation of the line passing through \\((1,2)\\) and perpendicular to the line \\(y=0\\)."
+      "$$x=1.$$"
+    ]
+    [
+      "makeCircLineInter"
+      "C34"
+      "Consider the line \\(x-y+1=0\\) and the circle \\( (x+5)^2+y^2=9\\). <br><br> Find out how many points of intersection they have, and the location of any intersections."
+      "The line and the circle intersect in two points, specifically $$\\left(\\frac{-6+\\sqrt{2}}{2},\\frac{-4+\\sqrt{2}}{2}\\right)\\qquad\\text{and}\\qquad \\left(\\frac{-6-\\sqrt{2}}{2},\\frac{-4-\\sqrt{2}}{2}\\right)$$"
     ]
     [
       "makeCArithmetic"

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -328,7 +328,7 @@ describe "mathmoController", ->
     [
       "makeFurtherVector"
       "F8"
-      "Let \\(a=\\begin{pmatrix}2\\\\2\\\\-5\\end{pmatrix}\\)\\,,\\; \\(b=\\begin{pmatrix}-2\\\\-3\\\\1\\end{pmatrix}\\,\\) and \\(c=\\begin{pmatrix}3\\\\3\\\\-3\\end{pmatrix}\\). Calculate: <ul class=\"exercise\"><li>the vector product, \\(a\\wedge b\\),</li><li>the scalar triple product, \\([a, b, c]\\).</li></ul>"
+      "Let \\(\\mathbf{a}=\\begin{pmatrix}2\\\\2\\\\-5\\end{pmatrix}\\,\\),\\; \\(\\mathbf{b}=\\begin{pmatrix}-2\\\\-3\\\\1\\end{pmatrix}\\,\\) and \\(\\mathbf{c}=\\begin{pmatrix}3\\\\3\\\\-3\\end{pmatrix}\\). Calculate: <ul class=\"exercise\"><li>the vector product, \\(\\mathbf{a}\\wedge \\mathbf{b}\\),</li><li>the scalar triple product, \\([\\mathbf{a}, \\mathbf{b}, \\mathbf{c}]\\).</li></ul>"
       "<ul class=\"exercise\"><li>\\(\\begin{pmatrix}-13\\\\8\\\\-2\\end{pmatrix}\\)</li><li>\\(-9\\)</li></ul>"
     ]
     [

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -362,12 +362,12 @@ describe "mathmoController", ->
       "$$240\\pi$$"
       2
     ]
-    # [ # Removed because currently giving NaN answers :(
-    #   "makeMatXforms"
-    #   "F13"
-    #   "q-F13"
-    #   "a-F13"
-    # ]
+    [
+      "makeMatXforms"
+      "F13"
+      "Compute the matrix representing, in 2D, an enlargement of scale factor \\(3\\) followed by a rotation through \\(\\frac{3}{2}\\pi\\) anticlockwise about O."
+      "$$\\left(\\begin{array}{cc}0&4\\\\-4&0\\end{array}\\right)$$"
+    ]
     [
       "makeDiscreteDistn"
       "S1"

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -304,8 +304,8 @@ describe "mathmoController", ->
     [
       "makeMatrix2"
       "F4"
-      "Let $$A=\\left(\\begin{array}{cc}5&-4\\\\-5&1\\end{array}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{array}{cc}-4&2\\\\5&3\\end{array}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
-      "<ul class=\"exercise\"><li>\\(\\left(\\begin{array}{cc}1&-2\\\\0&4\\end{array}\\right)\\)</li><li>\\(\\left(\\begin{array}{cc}-40&-2\\\\25&-7\\end{array}\\right)\\)</li><li>\\(\\left(\\begin{array}{cc}-\\frac{3}{22}&\\frac{1}{11}\\\\\\frac{5}{22}&\\frac{2}{11}\\end{array}\\right)\\)</li></ul>"
+      "Let $$A=\\left(\\begin{pmatrix}5&-4\\\\-5&1\\end{pmatrix}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{pmatrix}-4&2\\\\5&3\\end{pmatrix}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
+      "<ul class=\"exercise\"><li>\\(\\left(\\begin{pmatrix}1&-2\\\\0&4\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-40&-2\\\\25&-7\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-\\frac{3}{22}&\\frac{1}{11}\\\\\\frac{5}{22}&\\frac{2}{11}\\end{pmatrix}\\right)\\)</li></ul>"
     ]
     [
       "makeTaylor"
@@ -322,8 +322,8 @@ describe "mathmoController", ->
     [
       "makeMatrix3"
       "F7"
-      "Let $$A=\\left(\\begin{array}{ccc}3&1&2\\\\3&-3&1\\\\3&-4&-2\\end{array}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{array}{ccc}-4&-2&2\\\\-2&-2&3\\\\-3&3&2\\end{array}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
-      "<ul class=\"exercise\"><li>\\(\\left(\\begin{array}{ccc}-1&-1&4\\\\1&-5&4\\\\0&-1&0\\end{array}\\right)\\)</li><li>\\(\\left(\\begin{array}{ccc}-20&-2&13\\\\-9&3&-1\\\\2&-4&-10\\end{array}\\right)\\)</li><li>\\(\\left(\\begin{array}{ccc}-\\frac{13}{38}&\\frac{5}{19}&-\\frac{1}{19}\\\\-\\frac{5}{38}&-\\frac{1}{19}&\\frac{4}{19}\\\\-\\frac{6}{19}&\\frac{9}{19}&\\frac{2}{19}\\end{array}\\right)\\)</li></ul>"
+      "Let $$A=\\left(\\begin{pmatrix}3&1&2\\\\3&-3&1\\\\3&-4&-2\\end{pmatrix}\\right) \\qquad \\text{and} \\qquad B=\\left(\\begin{pmatrix}-4&-2&2\\\\-2&-2&3\\\\-3&3&2\\end{pmatrix}\\right)$$.Compute: <ul class=\"exercise\"><li>\\(A+B\\)</li><li>\\(A \\times B\\)</li><li>\\(B^{-1}\\)</li></ul>"
+      "<ul class=\"exercise\"><li>\\(\\left(\\begin{pmatrix}-1&-1&4\\\\1&-5&4\\\\0&-1&0\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-20&-2&13\\\\-9&3&-1\\\\2&-4&-10\\end{pmatrix}\\right)\\)</li><li>\\(\\left(\\begin{pmatrix}-\\frac{13}{38}&\\frac{5}{19}&-\\frac{1}{19}\\\\-\\frac{5}{38}&-\\frac{1}{19}&\\frac{4}{19}\\\\-\\frac{6}{19}&\\frac{9}{19}&\\frac{2}{19}\\end{pmatrix}\\right)\\)</li></ul>"
     ]
     [
       "makeFurtherVector"
@@ -366,7 +366,7 @@ describe "mathmoController", ->
       "makeMatXforms"
       "F13"
       "Compute the matrix representing, in 2D, an enlargement of scale factor \\(3\\) followed by a rotation through \\(\\frac{3}{2}\\pi\\) anticlockwise about O."
-      "$$\\left(\\begin{array}{cc}0&4\\\\-4&0\\end{array}\\right)$$"
+      "$$\\left(\\begin{pmatrix}0&4\\\\-4&0\\end{pmatrix}\\right)$$"
     ]
     [
       "makeDiscreteDistn"

--- a/test/pubs/mathmo/mathmoProblemsSpec.coffee
+++ b/test/pubs/mathmo/mathmoProblemsSpec.coffee
@@ -366,7 +366,7 @@ describe "mathmoController", ->
       "makeMatXforms"
       "F13"
       "Compute the matrix representing, in 2D, an enlargement of scale factor \\(3\\) followed by a rotation through \\(\\frac{3}{2}\\pi\\) anticlockwise about O."
-      "$$\\left(\\begin{pmatrix}0&4\\\\-4&0\\end{pmatrix}\\right)$$"
+      "$$\\begin{pmatrix}0&4\\\\-4&0\\end{pmatrix}$$"
     ]
     [
       "makeDiscreteDistn"


### PR DESCRIPTION
This pull request finishes the questions discussed in issue 16.

Specifically, it adds:
- A full question and answer for circle and line intersections, where the computer chooses between C/C, L/C and L/L
- Minor changes to the circle equations for prettier printing (736105b)
- A helper function for simplifying two part surds

Please also note the commit message for 27643e7 (specifically, an incorrect topicID which has now been fixed). You might need to clear your question store if you had the circle/line questions loaded.
